### PR TITLE
Use KUBECONFIG environment variable for kubeconfig path with fallback to default

### DIFF
--- a/krs/krs.py
+++ b/krs/krs.py
@@ -15,11 +15,15 @@ def check_initialized():
 if not os.path.exists(KRS_DATA_DIRECTORY):
     os.mkdir(KRS_DATA_DIRECTORY)
 
+def get_kubeconfig():
+    return os.getenv('KUBECONFIG', os.path.expanduser('~/.kube/config'))
+
 @app.command()
-def init(kubeconfig: str = typer.Option('~/.kube/config', help="Custom path for kubeconfig file if not default")):
+def init(kubeconfig: str = typer.Option(None, help="Custom path for kubeconfig file if not default")):
     """
     Initializes the services and loads the scanner.
     """
+    kubeconfig = kubeconfig or get_kubeconfig()
     krs.initialize(kubeconfig)
     typer.echo("Services initialized and scanner loaded.")
 


### PR DESCRIPTION
**Description:**

This PR introduces a feature that allows the `krs` CLI to use the `KUBECONFIG` environment variable to determine the path to the kubeconfig file. If the `KUBECONFIG` variable is not set or is empty, the CLI will default to using `~/.kube/config`.

### Key Changes:
- **KUBECONFIG Environment Variable:**
  - The CLI now checks for the `KUBECONFIG` environment variable to determine the kubeconfig file path.
  - If the environment variable is not set or is empty, the default path `~/.kube/config` is used.
  
- **`get_kubeconfig` Function:**
  - A new helper function `get_kubeconfig()` is introduced to handle the retrieval of the kubeconfig path based on the environment variable.
  
- **`init` Command Update:**
  - The `init` command now uses the `get_kubeconfig()` function to determine the kubeconfig file path, offering more flexibility for users.

### Why This Change?
- **Flexibility:** This update allows users to easily specify different kubeconfig files without needing to modify command options or the script itself.
- **Consistency:** By adhering to the common convention of using the `KUBECONFIG` environment variable, the CLI becomes more intuitive and consistent with other Kubernetes tools.

### How to Test:
1. Set the `KUBECONFIG` environment variable to a custom kubeconfig file path:
   ```bash
   export KUBECONFIG=/path/to/your/kubeconfig
   ```
2. Run the `init` command to ensure that the specified kubeconfig file is used:
   ```bash
   krs init
   ```
3. Unset the `KUBECONFIG` environment variable and rerun the `init` command to verify it defaults to `~/.kube/config`:
   ```bash
   unset KUBECONFIG
   krs init
   ```