### PR TITLE
Fix #71: Correct krs health for multi-container pods

### DIFF
--- a/build/lib/krs/utils/functional.py
+++ b/build/lib/krs/utils/functional.py
@@ -32,44 +32,51 @@ def filter_similar_entries(log_entries):
     filtered_entries = {entry for entry in unique_entries if entry not in to_remove}
     return filtered_entries
 
-def extract_log_entries(log_contents):
+def extract_log_entries(log_contents, container_state):
     # Patterns to match different log formats
     patterns = [
         re.compile(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z\s+(warn|error)\s+\S+\s+(.*)', re.IGNORECASE),
-        re.compile(r'[WE]\d{4} \d{2}:\d{2}:\d{2}.\d+\s+\d+\s+(.*)'),
-        re.compile(r'({.*})')  
+        re.compile(r'[WE]\d{4} \d{2}:\d{2}:\d{2}.\d+\s+\d+\s+(.*)'),                
+        re.compile(r'({.*})')
     ]
 
     log_entries = set()
-    # Attempt to match each line with all patterns
-    for line in log_contents.split('\n'):
-        for pattern in patterns:
-            match = pattern.search(line)
-            if match:
-                if match.groups()[0].startswith('{'):
-                    # Handle JSON formatted log entries
-                    try:
-                        log_json = json.loads(match.group(1))
-                        if 'severity' in log_json and log_json['severity'].lower() in ['error', 'warning']:
-                            level = "Error" if log_json['severity'] == "ERROR" else "Warning"
-                            message = log_json.get('error', '') if 'error' in log_json.keys() else line
-                            log_entries.add(f"{level}: {message.strip()}")
-                        elif 'level' in log_json:
-                            level = "Error" if log_json['level'] == "error" else "Warning"
-                            message = log_json.get('msg', '')  + log_json.get('error', '')
-                            log_entries.add(f"{level}: {message.strip()}")
-                    except json.JSONDecodeError:
-                        continue  # Skip if JSON is not valid
-                else:
-                    if len(match.groups()) == 2:
-                        level, message = match.groups()
-                    elif len(match.groups()) == 1:
-                        message = match.group(1)  # Assuming error as default
-                        level = "ERROR"  # Default if not specified in the log
+    # Attempt to match each line with all patterns    
+    for line in log_contents.split('\n'):             
+        if str(container_state) == 'None':
+            log_entries.add(line)
+        else:
+            for pattern in patterns:
+                match = pattern.search(line)
+                if match:                  
+                    if match.groups()[0].startswith('{'):                
+                        # Handle JSON formatted log entries
+                        try:
+                            log_json = json.loads(match.group(1))
+                            # print(log_json)
+                            if 'severity' in log_json and log_json['severity'].lower() in ['error', 'warning']:
+                                level = "Error" if log_json['severity'] == "ERROR" else "Warning"
+                                message = log_json.get('error', '') if 'error' in log_json.keys() else line
+                                log_entries.add(f"{level}: {message.strip()}")
+                            elif 'level' in log_json:
+                                level = "Error" if log_json['level'] == "error" else "Warning"
+                                message = log_json.get('msg', '')  + log_json.get('error', '')
+                                log_entries.add(f"{level}: {message.strip()}")
+                        except json.JSONDecodeError:
+                            continue  # Skip if JSON is not valid
+                    else:
+                        if len(match.groups()) == 2:
+                            level, message = match.groups()
+                        elif len(match.groups()) == 1:                
+                            message = match.group(1)  # Assuming error as default       
+                    
+                            level = "ERROR"  # Default if not specified in the log
 
-                    level = "Error" if "error" in level.lower() else "Warning"
-                    formatted_message = f"{level}: {message.strip()}"
-                    log_entries.add(formatted_message)
-                break  # Stop after the first match
-
+                        level = "Error" if "error" in level.lower() else "Warning"
+                        formatted_message = f"{level}: {message.strip()}"
+                        log_entries.add(formatted_message)
+                    break  # Stop after the first match
     return filter_similar_entries(log_entries)
+
+
+

--- a/krs/utils/functional.py
+++ b/krs/utils/functional.py
@@ -32,44 +32,51 @@ def filter_similar_entries(log_entries):
     filtered_entries = {entry for entry in unique_entries if entry not in to_remove}
     return filtered_entries
 
-def extract_log_entries(log_contents):
+def extract_log_entries(log_contents, container_state):
     # Patterns to match different log formats
     patterns = [
         re.compile(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z\s+(warn|error)\s+\S+\s+(.*)', re.IGNORECASE),
-        re.compile(r'[WE]\d{4} \d{2}:\d{2}:\d{2}.\d+\s+\d+\s+(.*)'),
-        re.compile(r'({.*})')  
+        re.compile(r'[WE]\d{4} \d{2}:\d{2}:\d{2}.\d+\s+\d+\s+(.*)'),                
+        re.compile(r'({.*})')
     ]
 
     log_entries = set()
-    # Attempt to match each line with all patterns
-    for line in log_contents.split('\n'):
-        for pattern in patterns:
-            match = pattern.search(line)
-            if match:
-                if match.groups()[0].startswith('{'):
-                    # Handle JSON formatted log entries
-                    try:
-                        log_json = json.loads(match.group(1))
-                        if 'severity' in log_json and log_json['severity'].lower() in ['error', 'warning']:
-                            level = "Error" if log_json['severity'] == "ERROR" else "Warning"
-                            message = log_json.get('error', '') if 'error' in log_json.keys() else line
-                            log_entries.add(f"{level}: {message.strip()}")
-                        elif 'level' in log_json:
-                            level = "Error" if log_json['level'] == "error" else "Warning"
-                            message = log_json.get('msg', '')  + log_json.get('error', '')
-                            log_entries.add(f"{level}: {message.strip()}")
-                    except json.JSONDecodeError:
-                        continue  # Skip if JSON is not valid
-                else:
-                    if len(match.groups()) == 2:
-                        level, message = match.groups()
-                    elif len(match.groups()) == 1:
-                        message = match.group(1)  # Assuming error as default
-                        level = "ERROR"  # Default if not specified in the log
+    # Attempt to match each line with all patterns    
+    for line in log_contents.split('\n'):             
+        if str(container_state) == 'None':
+            log_entries.add(line)
+        else:
+            for pattern in patterns:
+                match = pattern.search(line)
+                if match:                  
+                    if match.groups()[0].startswith('{'):                
+                        # Handle JSON formatted log entries
+                        try:
+                            log_json = json.loads(match.group(1))
+                            # print(log_json)
+                            if 'severity' in log_json and log_json['severity'].lower() in ['error', 'warning']:
+                                level = "Error" if log_json['severity'] == "ERROR" else "Warning"
+                                message = log_json.get('error', '') if 'error' in log_json.keys() else line
+                                log_entries.add(f"{level}: {message.strip()}")
+                            elif 'level' in log_json:
+                                level = "Error" if log_json['level'] == "error" else "Warning"
+                                message = log_json.get('msg', '')  + log_json.get('error', '')
+                                log_entries.add(f"{level}: {message.strip()}")
+                        except json.JSONDecodeError:
+                            continue  # Skip if JSON is not valid
+                    else:
+                        if len(match.groups()) == 2:
+                            level, message = match.groups()
+                        elif len(match.groups()) == 1:                
+                            message = match.group(1)  # Assuming error as default       
+                    
+                            level = "ERROR"  # Default if not specified in the log
 
-                    level = "Error" if "error" in level.lower() else "Warning"
-                    formatted_message = f"{level}: {message.strip()}"
-                    log_entries.add(formatted_message)
-                break  # Stop after the first match
-
+                        level = "Error" if "error" in level.lower() else "Warning"
+                        formatted_message = f"{level}: {message.strip()}"
+                        log_entries.add(formatted_message)
+                    break  # Stop after the first match
     return filter_similar_entries(log_entries)
+
+
+


### PR DESCRIPTION
## Fix for Issue #71: KRS Health Doesn't Work Correctly on Multi-Container Pods

### Description
This PR addresses the issue where `krs health` failed to correctly pull and analyze logs from multi-container pods. Specifically, the tool was hallucinating logs due to not pulling logs from all containers properly.

### Changes Made
- Added logic to check the status of each container within a pod. If it is not running, it will return the raw log of a specific failed container. 
- Updated the `get_logs_from_pod` function in the `main.py` file to correctly fetch logs from **all containers** within a pod.